### PR TITLE
🐛 Deactivate PDF Export for Documentation and Prepare Patch Release

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -41,11 +41,11 @@ build:
         - Z3_ROOT=~/z3-4.13.4-x64-glibc-2.35 uv run --frozen --no-dev --no-build-isolation-package mqt-qmap -m sphinx -T -b dirhtml -d docs/_build/doctrees -D language=en docs docs/_build/dirhtml
         - mkdir -p $READTHEDOCS_OUTPUT/htmlzip
         - zip -r $READTHEDOCS_OUTPUT/htmlzip/html.zip docs/_build/dirhtml/*
-      pdf:
-        - Z3_ROOT=~/z3-4.13.4-x64-glibc-2.35 uv run --frozen --no-dev --no-build-isolation-package mqt-qmap -m sphinx -T -b latex -d docs/_build/doctrees -D language=en docs docs/_build/latex
-        - cd docs/_build/latex && latexmk -pdf -f -dvi- -ps- -interaction=nonstopmode -jobname=$READTHEDOCS_PROJECT
-        - mkdir -p $READTHEDOCS_OUTPUT/pdf
-        - cp docs/_build/latex/$READTHEDOCS_PROJECT.pdf $READTHEDOCS_OUTPUT/pdf/$READTHEDOCS_PROJECT.pdf
+#      pdf:
+#        - Z3_ROOT=~/z3-4.13.4-x64-glibc-2.35 uv run --frozen --no-dev --no-build-isolation-package mqt-qmap -m sphinx -T -b latex -d docs/_build/doctrees -D language=en docs docs/_build/latex
+#        - cd docs/_build/latex && latexmk -pdf -f -dvi- -ps- -interaction=nonstopmode -jobname=$READTHEDOCS_PROJECT
+#        - mkdir -p $READTHEDOCS_OUTPUT/pdf
+#        - cp docs/_build/latex/$READTHEDOCS_PROJECT.pdf $READTHEDOCS_OUTPUT/pdf/$READTHEDOCS_PROJECT.pdf
 
 sphinx:
   configuration: docs/conf.py

--- a/docs/na_zoned_compiler.md
+++ b/docs/na_zoned_compiler.md
@@ -159,8 +159,8 @@ print(code)
 ```
 
 ```{note}
-The A* search in the placer of the routing aware compiler is quite memory intensive.
-Right now the maximum number of nodes considered in the A* search is limited to 50M.
+The A* search in the placer of the routing-aware compiler is quite memory intensive.
+Right now, the maximum number of nodes considered in the A* search is limited to 50M.
 If this limit is hit, you will get an error message. You can freely adapt this limit
 by setting the argument `max_nodes` in the constructor of the `RoutingAwareCompiler`, see below.
 ```


### PR DESCRIPTION
## Description

Curly braces in the Python code on the zoned neutral atom compiler page of the documentation cause an issue in the PDF export via LaTeX on readthedocs. Until we find another solution, this PR deactivates the PDF export for the documentation.

Additionally, it corrects two typos on the page for the zoned neutral atom compiler.

This PR also prepares the corresponding path release.

## Checklist:

<!---
This checklist serves as a reminder of a couple of things that ensure your pull request will be merged swiftly.
-->

- [x] The pull request only contains commits that are focused and relevant to this change.
- [ ] I have added appropriate tests that cover the new/changed functionality.
- [ ] I have updated the documentation to reflect these changes.
- [x] I have added entries to the changelog for any noteworthy additions, changes, fixes or removals.
- [ ] I have added migration instructions to the upgrade guide (if needed).
- [x] The changes follow the project's style guidelines and introduce no new warnings.
- [x] The changes are fully tested and pass the CI checks.
- [x] I have reviewed my own code changes.
