### PR TITLE
🐛 Fix CD

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -1,4 +1,5 @@
 name: CD 🚀
+# dummy change, remove before merge
 on:
   release:
     types: [published]

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -1,5 +1,4 @@
 name: CD 🚀
-# dummy change, remove before merge
 on:
   release:
     types: [published]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ This project adheres to [Semantic Versioning], with the exception that minor rel
 
 ## [Unreleased]
 
+## [3.1.3] - 2025-05-28
+
+### Fixed
+
+- 🐛 Fix the CD pipeline by changing the statistics struct in the zoned neutral atom compiler ([#661]) ([**@ystade**])
+
 ## [3.1.2] - 2025-05-27
 
 ### Fixed
@@ -63,7 +69,8 @@ _📚 Refer to the [GitHub Release Notes] for previous changelogs._
 
 <!-- Version links -->
 
-[unreleased]: https://github.com/munich-quantum-toolkit/qmap/compare/v3.1.2...HEAD
+[unreleased]: https://github.com/munich-quantum-toolkit/qmap/compare/v3.1.3...HEAD
+[3.1.3]: https://github.com/munich-quantum-toolkit/qmap/compare/v3.1.2...v3.1.3
 [3.1.2]: https://github.com/munich-quantum-toolkit/qmap/compare/v3.1.1...v3.1.2
 [3.1.1]: https://github.com/munich-quantum-toolkit/qmap/compare/v3.1.0...v3.1.1
 [3.1.0]: https://github.com/munich-quantum-toolkit/qmap/compare/v3.0.0...v3.1.0
@@ -72,6 +79,7 @@ _📚 Refer to the [GitHub Release Notes] for previous changelogs._
 
 <!-- PR links -->
 
+[#661]: https://github.com/munich-quantum-toolkit/qmap/pulls/661
 [#660]: https://github.com/munich-quantum-toolkit/qmap/pulls/660
 [#659]: https://github.com/munich-quantum-toolkit/qmap/pulls/659
 [#624]: https://github.com/munich-quantum-toolkit/qmap/pulls/624

--- a/src/na/zoned/reuse_analyzer/VertexMatchingReuseAnalyzer.cpp
+++ b/src/na/zoned/reuse_analyzer/VertexMatchingReuseAnalyzer.cpp
@@ -17,11 +17,9 @@
 #include <cassert>
 #include <cstddef>
 #include <deque>
-#include <iostream>
 #include <numeric>
 #include <optional>
 #include <queue>
-#include <sstream>
 #include <stack>
 #include <unordered_map>
 #include <unordered_set>
@@ -166,7 +164,8 @@ auto VertexMatchingReuseAnalyzer::maximumBipartiteMatching(
     for (std::size_t freeSource = 0; freeSource < freeSources.size();
          ++freeSource) {
       if (freeSources[freeSource]) {
-        std::stack stack(std::deque{freeSource});
+        std::stack<std::size_t, std::deque<std::size_t>> stack(
+            std::deque<std::size_t>{freeSource});
         // this vector tracks the predecessors of each source, i.e., the sink
         // AND the source coming before the source in the augmenting path
         std::vector<std::optional<std::pair<std::size_t, std::size_t>>> parents(


### PR DESCRIPTION
## Description

Since the addition of the Zoned Neutral Atom Compiler the CD keeps to fail even though all tests succeed. The issue seems to be related to the serialization of `chrono::micorseconds`. On many systems, this serialization is not defined and was manually defined in `include/na/zoned/Compiler.hpp`. Apparently, on the Linux systems used for building the wheels, this serialization function is already defined. To circumvent this issue, the type of the members in the statistics structure was changed to `int64_t` returned by `chrono::micorseconds::count()`, and the serialization was removed.

Additionally, this PR prepares the next patch release.

## Checklist:

<!---
This checklist serves as a reminder of a couple of things that ensure your pull request will be merged swiftly.
-->

- [x] The pull request only contains commits that are focused and relevant to this change.
- [ ] I have added appropriate tests that cover the new/changed functionality.
- [x] I have updated the documentation to reflect these changes.
- [x] I have added entries to the changelog for any noteworthy additions, changes, fixes or removals.
- [ ] I have added migration instructions to the upgrade guide (if needed).
- [x] The changes follow the project's style guidelines and introduce no new warnings.
- [x] The changes are fully tested and pass the CI checks.
- [x] I have reviewed my own code changes.
