### PR TITLE
🐛 Fix Lookup of Discrete Columns in routing-aware Compiler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ This project adheres to [Semantic Versioning], with the exception that minor rel
 
 ### Fixed
 
-- 🐛 Fix Lookup of Discrete Columns in routing-aware Compiler ([#728]) ([**@ystade**])
+- 🐛 Fix lookup of discrete columns in routing-aware compiler ([#728]) ([**@ystade**])
 
 ## [3.3.0] - 2025-08-04
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ This project adheres to [Semantic Versioning], with the exception that minor rel
 
 ## [Unreleased]
 
+### Fixed
+
+- 🐛 Fix Lookup of Discrete Columns in routing-aware Compiler ([#728]) ([**@ystade**])
+
 ## [3.3.0] - 2025-08-04
 
 _If you are upgrading: please see [`UPGRADING.md`](UPGRADING.md#330)._
@@ -122,6 +126,7 @@ _📚 Refer to the [GitHub Release Notes] for previous changelogs._
 
 <!-- PR links -->
 
+[#728]: https://github.com/munich-quantum-toolkit/qmap/pull/728
 [#720]: https://github.com/munich-quantum-toolkit/qmap/pull/720
 [#719]: https://github.com/munich-quantum-toolkit/qmap/pull/719
 [#717]: https://github.com/munich-quantum-toolkit/qmap/pull/717

--- a/src/na/zoned/layout_synthesizer/placer/AStarPlacer.cpp
+++ b/src/na/zoned/layout_synthesizer/placer/AStarPlacer.cpp
@@ -837,7 +837,8 @@ auto AStarPlacer::placeAtomsInStorageZone(
         architecture_.get().nearestStorageSite(previousSLM, previousRow,
                                                previousCol);
     uint8_t discreteColumnOfNearestSite = 0;
-    const auto& it = discreteTargetColumns.find(std::pair{std::cref(nearestSLM), nearestCol});
+    const auto& it = discreteTargetColumns.find(
+        std::pair{std::cref(nearestSLM), nearestCol});
     if (it != discreteTargetColumns.end()) {
       discreteColumnOfNearestSite = it->second;
     } else {
@@ -847,10 +848,11 @@ auto AStarPlacer::placeAtomsInStorageZone(
       for (const auto& [SlmColumn, discreteColumn] : discreteTargetColumns) {
         const auto& [slm, column] = SlmColumn;
         if (slm.get() == nearestSLM.get()) {
-          if (std::abs(static_cast<int64_t>(column) - static_cast<int64_t>(nearestCol)) <
-              distance) {
+          if (std::abs(static_cast<int64_t>(column) -
+                       static_cast<int64_t>(nearestCol)) < distance) {
             discreteColumnOfNearestSite = discreteColumn;
-            distance = std::abs(static_cast<int64_t>(column) - static_cast<int64_t>(nearestCol));
+            distance = std::abs(static_cast<int64_t>(column) -
+                                static_cast<int64_t>(nearestCol));
           }
         }
       }

--- a/src/na/zoned/layout_synthesizer/placer/AStarPlacer.cpp
+++ b/src/na/zoned/layout_synthesizer/placer/AStarPlacer.cpp
@@ -848,8 +848,9 @@ auto AStarPlacer::placeAtomsInStorageZone(
       for (const auto& [SlmColumn, discreteColumn] : discreteTargetColumns) {
         const auto& [slm, column] = SlmColumn;
         if (slm.get() == nearestSLM.get()) {
-          if (const auto currentDistance = std::abs(static_cast<int64_t>(column) -
-                       static_cast<int64_t>(nearestCol)) < minDistance) {
+          if (const auto currentDistance =
+                  std::abs(static_cast<int64_t>(column) -
+                           static_cast<int64_t>(nearestCol)) < minDistance) {
             discreteColumnOfNearestSite = discreteColumn;
             minDistance = currentDistance;
           }

--- a/src/na/zoned/layout_synthesizer/placer/AStarPlacer.cpp
+++ b/src/na/zoned/layout_synthesizer/placer/AStarPlacer.cpp
@@ -836,8 +836,25 @@ auto AStarPlacer::placeAtomsInStorageZone(
     const auto& [nearestSLM, nearestRow, nearestCol] =
         architecture_.get().nearestStorageSite(previousSLM, previousRow,
                                                previousCol);
-    const auto discreteColumnOfNearestSite =
-        discreteTargetColumns.at(std::pair{std::cref(nearestSLM), nearestCol});
+    uint8_t discreteColumnOfNearestSite = 0;
+    const auto& it = discreteTargetColumns.find(std::pair{std::cref(nearestSLM), nearestCol});
+    if (it != discreteTargetColumns.end()) {
+      discreteColumnOfNearestSite = it->second;
+    } else {
+      // distance of the actual (occupied) nearest column and a column with free
+      // sites
+      int64_t distance = std::numeric_limits<int64_t>::max();
+      for (const auto& [SlmColumn, discreteColumn] : discreteTargetColumns) {
+        const auto& [slm, column] = SlmColumn;
+        if (slm.get() == nearestSLM.get()) {
+          if (std::abs(static_cast<int64_t>(column) - static_cast<int64_t>(nearestCol)) <
+              distance) {
+            discreteColumnOfNearestSite = discreteColumn;
+            distance = std::abs(static_cast<int64_t>(column) - static_cast<int64_t>(nearestCol));
+          }
+        }
+      }
+    }
     minDiscreteColumnOfNearestSite =
         std::min(minDiscreteColumnOfNearestSite, discreteColumnOfNearestSite);
     maxDiscreteColumnOfNearestSite =

--- a/src/na/zoned/layout_synthesizer/placer/AStarPlacer.cpp
+++ b/src/na/zoned/layout_synthesizer/placer/AStarPlacer.cpp
@@ -844,15 +844,14 @@ auto AStarPlacer::placeAtomsInStorageZone(
     } else {
       // distance of the actual (occupied) nearest column and a column with free
       // sites
-      int64_t distance = std::numeric_limits<int64_t>::max();
+      int64_t minDistance = std::numeric_limits<int64_t>::max();
       for (const auto& [SlmColumn, discreteColumn] : discreteTargetColumns) {
         const auto& [slm, column] = SlmColumn;
         if (slm.get() == nearestSLM.get()) {
-          if (std::abs(static_cast<int64_t>(column) -
-                       static_cast<int64_t>(nearestCol)) < distance) {
+          if (const auto currentDistance = std::abs(static_cast<int64_t>(column) -
+                       static_cast<int64_t>(nearestCol)) < minDistance) {
             discreteColumnOfNearestSite = discreteColumn;
-            distance = std::abs(static_cast<int64_t>(column) -
-                                static_cast<int64_t>(nearestCol));
+            minDistance = currentDistance;
           }
         }
       }

--- a/test/na/zoned/test_compiler.cpp
+++ b/test/na/zoned/test_compiler.cpp
@@ -129,4 +129,76 @@ constexpr std::string_view routingAwareConfiguration = R"({
 /*============================== INSTANTIATIONS ==============================*/
 COMPILER_TEST(RoutingAgnosticCompiler, routingAgnosticConfiguration);
 COMPILER_TEST(RoutingAwareCompiler, routingAwareConfiguration);
+
+// Tests that the bug described in issue #727 is fixed.
+constexpr std::string_view architectureSpecification727 = R"({
+  "name": "Architecture with one entanglement and one storage zone",
+  "operation_duration": {
+    "rydberg_gate": 0.36,
+    "single_qubit_gate": 52,
+    "atom_transfer": 15
+  },
+  "operation_fidelity": {
+    "rydberg_gate": 0.995,
+    "single_qubit_gate": 0.9997,
+    "atom_transfer": 0.999
+  },
+  "qubit_spec": { "T": 1.5e6 },
+  "storage_zones": [
+    {
+      "zone_id": 0,
+      "slms": [
+        {
+          "id": 0,
+          "site_separation": [3, 3],
+          "r": 5,
+          "c": 10,
+          "location": [42, 30]
+        }
+      ],
+      "offset": [0, 0],
+      "dimension": [297, 57]
+    }
+  ],
+  "entanglement_zones": [
+    {
+      "zone_id": 0,
+      "slms": [
+        {
+          "id": 1,
+          "site_separation": [12, 10],
+          "r": 2,
+          "c": 4,
+          "location": [35, 67]
+        },
+        {
+          "id": 2,
+          "site_separation": [12, 10],
+          "r": 2,
+          "c": 4,
+          "location": [37, 67]
+        }
+      ],
+      "offset": [35, 67],
+      "dimension": [230, 60]
+    }
+  ],
+  "aods": [{ "id": 0, "site_separation": 2, "r": 100, "c": 100 }],
+  "rydberg_range": [
+    [
+      [30, 62],
+      [80, 82]
+    ]
+  ]
+})";
+
+TEST(RoutingAwareCompilerTest, Issue727) {
+  qc::QuantumComputation circ(50);
+  circ.cz(0, 3);
+  const auto arch = Architecture::fromJSONString(
+                                       architectureSpecification727);
+  RoutingAwareCompiler compiler(arch);
+  const auto& code = compiler.compile(circ);
+  EXPECT_TRUE(code.validate().first);
+}
 } // namespace na::zoned

--- a/test/na/zoned/test_compiler.cpp
+++ b/test/na/zoned/test_compiler.cpp
@@ -130,7 +130,8 @@ constexpr std::string_view routingAwareConfiguration = R"({
 COMPILER_TEST(RoutingAgnosticCompiler, routingAgnosticConfiguration);
 COMPILER_TEST(RoutingAwareCompiler, routingAwareConfiguration);
 
-// Tests that the bug described in issue https://github.com/munich-quantum-toolkit/qmap/issues/727 is fixed.
+// Tests that the bug described in issue
+// https://github.com/munich-quantum-toolkit/qmap/issues/727 is fixed.
 constexpr std::string_view architectureSpecification727 = R"({
   "name": "Architecture with one entanglement and one storage zone",
   "operation_duration": {

--- a/test/na/zoned/test_compiler.cpp
+++ b/test/na/zoned/test_compiler.cpp
@@ -130,7 +130,7 @@ constexpr std::string_view routingAwareConfiguration = R"({
 COMPILER_TEST(RoutingAgnosticCompiler, routingAgnosticConfiguration);
 COMPILER_TEST(RoutingAwareCompiler, routingAwareConfiguration);
 
-// Tests that the bug described in issue #727 is fixed.
+// Tests that the bug described in issue https://github.com/munich-quantum-toolkit/qmap/issues/727 is fixed.
 constexpr std::string_view architectureSpecification727 = R"({
   "name": "Architecture with one entanglement and one storage zone",
   "operation_duration": {

--- a/test/na/zoned/test_compiler.cpp
+++ b/test/na/zoned/test_compiler.cpp
@@ -195,8 +195,7 @@ constexpr std::string_view architectureSpecification727 = R"({
 TEST(RoutingAwareCompilerTest, Issue727) {
   qc::QuantumComputation circ(50);
   circ.cz(0, 3);
-  const auto arch = Architecture::fromJSONString(
-                                       architectureSpecification727);
+  const auto arch = Architecture::fromJSONString(architectureSpecification727);
   RoutingAwareCompiler compiler(arch);
   const auto& code = compiler.compile(circ);
   EXPECT_TRUE(code.validate().first);


### PR DESCRIPTION
<!--- This file has been generated from an external template. Please do not modify it directly. -->
<!--- Changes should be contributed to https://github.com/munich-quantum-toolkit/templates. -->

## Description

At the moment when atoms are moved back from the entanglement zone to the storage zone, the nearest site is used as a reference. However, when no site was free in the column of the nearest site, then a lookup in the map of discretized column indices would lead to a segmentation fault. This is fixed now. If the case described before happens, the column closest to the column of the nearest site is taken.

Fixes #727

## Checklist:

<!---
This checklist serves as a reminder of a couple of things that ensure your pull request will be merged swiftly.
-->

- [x] The pull request only contains commits that are focused and relevant to this change.
- [x] I have added appropriate tests that cover the new/changed functionality.
- [x] I have updated the documentation to reflect these changes.
- [x] I have added entries to the changelog for any noteworthy additions, changes, fixes, or removals.
- [x] I have added migration instructions to the upgrade guide (if needed).
- [x] The changes follow the project's style guidelines and introduce no new warnings.
- [x] The changes are fully tested and pass the CI checks.
- [x] I have reviewed my own code changes.
