### PR TITLE
🍎 Restore support for x86 macOS systems

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -26,6 +26,7 @@ jobs:
           [
             ubuntu-24.04,
             ubuntu-24.04-arm,
+            macos-15-intel,
             macos-14,
             windows-2022,
             windows-11-arm,

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,9 +44,13 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        runs-on: [macos-14]
+        runs-on: [macos-15-intel, macos-14]
         compiler: [clang]
-        config: [Release, Debug]
+        config: [Release]
+        include:
+          - runs-on: macos-14
+            compiler: clang
+            config: Debug
     uses: munich-quantum-toolkit/workflows/.github/workflows/reusable-cpp-tests-macos.yml@56cf3608b07dc10bda5b98d77ed6ad21ecf7ef5d # v1.17.0
     with:
       runs-on: ${{ matrix.runs-on }}
@@ -109,7 +113,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        runs-on: [macos-14, macos-15]
+        runs-on: [macos-14, macos-15-intel, macos-15]
         compiler: [clang, clang-19, clang-20, gcc-14, gcc-15]
         config: [Release, Debug]
         exclude:
@@ -177,7 +181,14 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        runs-on: [ubuntu-24.04, ubuntu-24.04-arm, macos-14, windows-2022]
+        runs-on:
+          [
+            ubuntu-24.04,
+            ubuntu-24.04-arm,
+            macos-15-intel,
+            macos-14,
+            windows-2022,
+          ]
     uses: munich-quantum-toolkit/workflows/.github/workflows/reusable-python-tests.yml@56cf3608b07dc10bda5b98d77ed6ad21ecf7ef5d # v1.17.0
     with:
       runs-on: ${{ matrix.runs-on }}
@@ -234,6 +245,7 @@ jobs:
           [
             ubuntu-24.04,
             ubuntu-24.04-arm,
+            macos-15-intel,
             macos-14,
             windows-2022,
             windows-11-arm,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,6 @@ This project adheres to [Semantic Versioning], with the exception that minor rel
 ### Removed
 
 - 🔥 Drop support for Python 3.9 ([#767]) ([**@denialhaag**])
-- 🔥 Stop testing on and shipping wheels for x86 macOS systems ([#760]) ([**@denialhaag**])
 
 ## [3.3.1] - 2025-08-07
 

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -4,13 +4,6 @@ This document describes breaking changes and how to upgrade. For a complete list
 
 ## [Unreleased]
 
-### End of support for x86 macOS systems
-
-Starting with this release, MQT QMAP no longer ships Python wheels for x86 macOS systems.
-This comes as a result of GitHub removing the `macos-13` runners from their infrastructure.
-Users on x86 macOS systems can still install MQT QMAP from source as we continue to ship a source distribution.
-However, these systems are no longer tested in our CI and we can no longer guarantee that MQT QMAP builds and runs correctly.
-
 ### End of support for Python 3.9
 
 Starting with this release, MQT QMAP no longer supports Python 3.9.


### PR DESCRIPTION
## Description

This PR reverts #760, which dropped support for x86 macOS systems. This is because GitHub Actions has introduced a `macos-15-intel` runner, enabling us to test on x86 macOS until August 2027.

Furthermore, this PR improves `nox` sessions that manipulate the lock file to ensure that any potential changes are fully undone.  

## Checklist:

- [x] The pull request only contains commits that are focused and relevant to this change.
- [x] ~I have added appropriate tests that cover the new/changed functionality.~
- [x] ~I have updated the documentation to reflect these changes.~
- [x] ~I have added entries to the changelog for any noteworthy additions, changes, fixes, or removals.~
- [x] ~I have added migration instructions to the upgrade guide (if needed).~
- [x] The changes follow the project's style guidelines and introduce no new warnings.
- [x] The changes are fully tested and pass the CI checks.
- [x] I have reviewed my own code changes.
