### PR TITLE
♻️ Move output measurement construction to QMAP

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -336,6 +336,7 @@ _📚 Refer to the [GitHub Release Notes] for previous changelogs._
 <!-- Contributor -->
 
 [**@burgholzer**]: https://github.com/burgholzer
+[**@simon1hofmann**]: https://github.com/simon1hofmann
 [**@ystade**]: https://github.com/ystade
 [**@denialhaag**]: https://github.com/denialhaag
 [**@lsschmid**]: https://github.com/lsschmid

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ _If you are upgrading: please see [`UPGRADING.md`](UPGRADING.md#unreleased)._
 
 ### Changed
 
+- ♻️ Move output-permutation measurement construction from MQT Core into QMAP
+  ([#1106]) ([**@simon1hofmann**])
 - ⬆️ Update `nanobind` to version 2.14.0 ([#1105]) ([**@denialhaag**])
 - ⬆️ Update `mqt-core` to version 3.8.0 ([#1093]) ([**@denialhaag**])
 
@@ -284,6 +286,7 @@ _📚 Refer to the [GitHub Release Notes] for previous changelogs._
 
 <!-- PR links -->
 
+[#1106]: https://github.com/munich-quantum-toolkit/qmap/pull/1106
 [#1105]: https://github.com/munich-quantum-toolkit/qmap/pull/1105
 [#1096]: https://github.com/munich-quantum-toolkit/qmap/pull/1096
 [#1093]: https://github.com/munich-quantum-toolkit/qmap/pull/1093

--- a/src/sc/Mapper.cpp
+++ b/src/sc/Mapper.cpp
@@ -27,8 +27,6 @@
 #include <limits>
 #include <optional>
 #include <set>
-#include <stdexcept>
-#include <string>
 #include <utility>
 #include <vector>
 
@@ -40,16 +38,7 @@ void appendMeasurementsAccordingToOutputPermutation(
     qc::QuantumComputation& circuit) {
   constexpr auto registerName = "c";
   const auto numOutputs = circuit.outputPermutation.size();
-  const auto& classicalRegisters = circuit.getClassicalRegisters();
-  if (classicalRegisters.empty()) {
-    circuit.addClassicalRegister(numOutputs, registerName);
-  } else if (circuit.getNcbits() < numOutputs) {
-    if (classicalRegisters.contains(registerName)) {
-      throw std::runtime_error("Register c already exists but is too small");
-    }
-    circuit.addClassicalRegister(numOutputs - circuit.getNcbits(),
-                                 registerName);
-  }
+  circuit.addClassicalRegister(numOutputs, registerName);
 
   circuit.barrier();
   for (const auto& [qubit, clbit] : circuit.outputPermutation) {

--- a/src/sc/Mapper.cpp
+++ b/src/sc/Mapper.cpp
@@ -27,8 +27,36 @@
 #include <limits>
 #include <optional>
 #include <set>
+#include <stdexcept>
+#include <string>
 #include <utility>
 #include <vector>
+
+namespace {
+/**
+ * @brief Append measurements matching the circuit's output permutation.
+ */
+void appendMeasurementsAccordingToOutputPermutation(
+    qc::QuantumComputation& circuit) {
+  constexpr auto registerName = "c";
+  const auto numOutputs = circuit.outputPermutation.size();
+  const auto& classicalRegisters = circuit.getClassicalRegisters();
+  if (classicalRegisters.empty()) {
+    circuit.addClassicalRegister(numOutputs, registerName);
+  } else if (circuit.getNcbits() < numOutputs) {
+    if (classicalRegisters.contains(registerName)) {
+      throw std::runtime_error("Register c already exists but is too small");
+    }
+    circuit.addClassicalRegister(numOutputs - circuit.getNcbits(),
+                                 registerName);
+  }
+
+  circuit.barrier();
+  for (const auto& [qubit, clbit] : circuit.outputPermutation) {
+    circuit.measure(qubit, clbit);
+  }
+}
+} // namespace
 
 void Mapper::initResults() {
   countGates(qc, results.input);
@@ -475,7 +503,7 @@ void Mapper::finalizeMappedCircuit() {
 
   // append measurements according to output permutation
   if (results.config.addMeasurementsToMappedCircuit) {
-    qcMapped.appendMeasurementsAccordingToOutputPermutation();
+    appendMeasurementsAccordingToOutputPermutation(qcMapped);
   }
 }
 

--- a/test/sc/heuristic/test_heuristic.cpp
+++ b/test/sc/heuristic/test_heuristic.cpp
@@ -948,6 +948,31 @@ TEST(Functionality, NoMeasurementsAdded) {
   EXPECT_NE(qcMapped.back()->getType(), qc::Measure);
 }
 
+TEST(Functionality, MeasurementsFollowOutputPermutation) {
+  using namespace qc::literals;
+  qc::QuantumComputation qc{3U};
+  qc.cx(0_pc, 1);
+  qc.cx(1_pc, 2);
+
+  Architecture arch{3U, {{0, 1}, {1, 2}}};
+  HeuristicMapper mapper(qc, arch);
+  Configuration config{};
+  config.initialLayout = InitialLayout::Identity;
+  config.addMeasurementsToMappedCircuit = true;
+  mapper.map(config);
+
+  const auto mapped = mapper.moveMappedCircuit();
+  EXPECT_EQ(mapped.getNcbits(), mapped.outputPermutation.size());
+  EXPECT_EQ(
+      std::ranges::count_if(
+          mapped, [](const auto& op) { return op->getType() == qc::Measure; }),
+      mapped.outputPermutation.size());
+  ASSERT_GE(mapped.getNops(), mapped.outputPermutation.size() + 1U);
+  EXPECT_EQ(mapped.at(mapped.getNops() - mapped.outputPermutation.size() - 1U)
+                ->getType(),
+            qc::Barrier);
+}
+
 TEST(Functionality, InvalidCircuits) {
   Configuration config{};
   config.method = Method::Heuristic;


### PR DESCRIPTION
🤖 *AI text below* 🤖

## Description

Moves construction of mapped-circuit measurements into QMAP as a companion to [MQT Core #2112](https://github.com/munich-quantum-toolkit/core/pull/2112).

The mapper now locally appends the barrier and measurements described by its output permutation, including provisioning a suitable classical register. This preserves QMAP behavior while allowing the QMAP-specific helper to be removed from Core.

A regression test verifies the classical-bit count, measurement count, and barrier placement. The implementation only uses APIs available in the current Core release, so this PR can merge independently of the Core PR.

## Validation

- Release build
- Focused heuristic mapper tests
- Full lint suite

AI assistance was used to move the behavior, add its regression test, validate the change, and prepare this pull request. The contributor remains responsible for reviewing and understanding the changes.

## Checklist

- [x] The pull request only contains commits that are focused and relevant to this change.
- [x] I have added appropriate tests that cover the new/changed functionality.
- [x] I have updated the documentation to reflect these changes.
- [x] I have added entries to the changelog for any noteworthy additions, changes, fixes, or removals.
- [x] I have added migration instructions to the upgrade guide (if needed).
- [x] The changes follow the project's style guidelines and introduce no new warnings.
- [x] The changes are fully tested and pass the CI checks.
- [ ] I have reviewed my own code changes.

**If PR contains AI-assisted content:**

- [x] Any agent that created, edited, or submitted GitHub content was explicitly authorized for that scope, as required by our AI Usage Guidelines.
- [x] Every agent-authored or agent-edited public text body begins with the visible disclosure `🤖 *AI text below* 🤖` (titles are exempt).
- [x] I have disclosed AI assistance in the PR description.
- [ ] I confirm that I have personally reviewed and understood all AI-generated content, and accept full responsibility for it.
