### PR TITLE
🐛 Handle optional Qiskit target properties

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,11 @@ _If you are upgrading: please see [`UPGRADING.md`](UPGRADING.md#unreleased)._
   ([#1126]) ([**@denialhaag**])
 - 💥 Require Python 3.11 or newer ([#1126]) ([**@denialhaag**])
 
+### Fixed
+
+- 🐛 Handle Qiskit targets without calibration properties ([#1152])
+  ([**@burgholzer**])
+
 ## [3.9.0] - 2026-08-24
 
 _If you are upgrading: please see [`UPGRADING.md`](UPGRADING.md#390)._
@@ -299,6 +304,7 @@ _📚 Refer to the [GitHub Release Notes] for previous changelogs._
 
 <!-- PR links -->
 
+[#1152]: https://github.com/munich-quantum-toolkit/qmap/pull/1152
 [#1126]: https://github.com/munich-quantum-toolkit/qmap/pull/1126
 [#1116]: https://github.com/munich-quantum-toolkit/qmap/pull/1116
 [#1106]: https://github.com/munich-quantum-toolkit/qmap/pull/1106

--- a/python/mqt/qmap/plugins/qiskit/sc/import_backend.py
+++ b/python/mqt/qmap/plugins/qiskit/sc/import_backend.py
@@ -29,19 +29,28 @@ def import_target(target: Target) -> Architecture.Properties:
         The imported target as an Architecture.Properties object.
     """
     props = Architecture.Properties()
-    props.num_qubits = len(target.qubit_properties)
+    if target.num_qubits is None:
+        msg = "Cannot import an unbounded Qiskit target."
+        raise ValueError(msg)
+    props.num_qubits = target.num_qubits
 
-    for i in range(props.num_qubits):
-        qubit_props = target.qubit_properties[i]
-        props.set_t1(i, qubit_props.t1)
-        props.set_t2(i, qubit_props.t2)
-        props.set_frequency(i, qubit_props.frequency)
+    for i, qubit_props in enumerate(target.qubit_properties or ()):
+        if qubit_props is None:
+            continue
+        if qubit_props.t1 is not None:
+            props.set_t1(i, qubit_props.t1)
+        if qubit_props.t2 is not None:
+            props.set_t2(i, qubit_props.t2)
+        if qubit_props.frequency is not None:
+            props.set_frequency(i, qubit_props.frequency)
 
     for instruction, qargs in target.instructions:
-        if instruction.name in {"reset", "delay"}:
+        if instruction.name in {"reset", "delay"} or qargs is None:
             continue
 
         instruction_props = target[instruction.name][qargs]
+        if instruction_props is None or instruction_props.error is None:
+            continue
         if instruction.name == "measure":
             props.set_readout_error(qargs[0], instruction_props.error)
         elif len(qargs) == 1:

--- a/test/python/sc/test_qiskit_backend_imports.py
+++ b/test/python/sc/test_qiskit_backend_imports.py
@@ -13,9 +13,45 @@ from __future__ import annotations
 import pytest
 from mqt.qcec import verify
 from qiskit import QuantumCircuit
+from qiskit.circuit import Measure
+from qiskit.circuit.library import CXGate, HGate
+from qiskit.providers import BackendV2, Options, QubitProperties
 from qiskit.providers.fake_provider import GenericBackendV2
+from qiskit.transpiler import InstructionProperties, Target
 
-from mqt.qmap.plugins.qiskit.sc import compile_
+from mqt.qmap.plugins.qiskit.sc import compile_, import_backend, import_target
+
+
+class MinimalBackend(BackendV2):
+    """Backend without calibration properties."""
+
+    def __init__(self) -> None:
+        """Initialize the backend."""
+        super().__init__()
+        target = Target(num_qubits=3)
+        target.add_instruction(HGate(), {(0,): None, (1,): None, (2,): None})
+        target.add_instruction(CXGate(), {(0, 1): None, (1, 2): None})
+        target.add_instruction(Measure(), {(0,): None, (1,): None, (2,): None})
+        self._target = target
+
+    @property
+    def target(self) -> Target:
+        """Backend target."""
+        return self._target
+
+    @property
+    def max_circuits(self) -> int | None:
+        """Maximum number of circuits per job."""
+        return None
+
+    @classmethod
+    def _default_options(cls) -> Options:
+        """Return the default backend options."""
+        return Options()
+
+    def run(self, *args: object, **kwargs: object) -> None:
+        """This backend is only used for compilation."""
+        raise NotImplementedError
 
 
 @pytest.fixture
@@ -47,3 +83,52 @@ def test_architecture_from_v2_target(example_circuit: QuantumCircuit, backend: G
     qc, results = compile_(example_circuit, arch=None, calibration=backend.target)
     assert results.timeout is False
     assert verify(example_circuit, qc).considered_equivalent()
+
+
+def test_backend_without_calibration_properties(example_circuit: QuantumCircuit) -> None:
+    """Test importing a backend that does not provide calibration properties."""
+    backend = MinimalBackend()
+    mapped, results = compile_(example_circuit, arch=backend)
+
+    architecture = import_backend(backend)
+    assert architecture.num_qubits == 3
+    assert architecture.coupling_map == {(0, 1), (1, 2)}
+    assert architecture.properties.num_qubits == 3
+    with pytest.raises(IndexError):
+        architecture.properties.get_two_qubit_error(0, 1, "cx")
+    assert results.timeout is False
+    assert verify(example_circuit, mapped).considered_equivalent()
+
+
+def test_partially_missing_target_properties() -> None:
+    """Test that unavailable calibration values remain unavailable."""
+    target = Target(
+        num_qubits=2,
+        qubit_properties=[QubitProperties(t1=1.0), QubitProperties()],
+    )
+    target.add_instruction(
+        HGate(),
+        {
+            (0,): InstructionProperties(error=0.01),
+            (1,): InstructionProperties(error=None),
+        },
+    )
+
+    properties = import_target(target)
+    assert properties.num_qubits == 2
+    assert properties.get_t1(0) == pytest.approx(1.0)
+    assert properties.get_single_qubit_error(0, "h") == pytest.approx(0.01)
+    with pytest.raises(IndexError):
+        properties.get_t2(0)
+    with pytest.raises(IndexError):
+        properties.get_frequency(0)
+    with pytest.raises(IndexError):
+        properties.get_t1(1)
+    with pytest.raises(IndexError):
+        properties.get_single_qubit_error(1, "h")
+
+
+def test_unbounded_target() -> None:
+    """Test that an unbounded target cannot be imported."""
+    with pytest.raises(ValueError, match="unbounded Qiskit target"):
+        import_target(Target(num_qubits=None))


### PR DESCRIPTION
🤖 *AI text below* 🤖

## Description

Handle finite Qiskit targets whose optional qubit or instruction calibration properties are unavailable. Missing values remain absent instead of being treated as zero-error calibration data, while unbounded targets now fail with a direct diagnostic.

Fixes #1149

## Checklist

- [x] The pull request only contains commits that are focused and relevant to this change.
- [x] I have added appropriate tests that cover the new/changed functionality.
- [x] I have updated the documentation to reflect these changes.
- [x] I have added entries to the changelog for any noteworthy additions, changes, fixes, or removals.
- [x] I have added migration instructions to the upgrade guide (if needed).
- [x] The changes follow the project's style guidelines and introduce no new warnings.
- [x] The changes are fully tested and pass the CI checks.
- [x] I have reviewed my own code changes.

**If PR contains AI-assisted content:**

- [x] Any agent that created, edited, or submitted GitHub content was explicitly authorized for that scope, as required by our [AI Usage Guidelines](https://github.com/munich-quantum-toolkit/qmap/blob/main/docs/ai_usage.md).
- [x] Every agent-authored or agent-edited public text body begins with the visible disclosure `🤖 *AI text below* 🤖` (titles are exempt).
- [x] I have disclosed AI assistance in the PR description.
- [x] I confirm that I have personally reviewed and understood all AI-generated content, and accept full responsibility for it.