### PR TITLE
🐛 Preserve circuit names during mapping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,8 @@ _If you are upgrading: please see [`UPGRADING.md`](UPGRADING.md#unreleased)._
 
 ### Fixed
 
+- 🐛 Preserve the input circuit name during mapping ([#1154])
+  ([**@burgholzer**])
 - 🐛 Handle Qiskit targets without calibration properties ([#1152])
   ([**@burgholzer**])
 
@@ -304,6 +306,7 @@ _📚 Refer to the [GitHub Release Notes] for previous changelogs._
 
 <!-- PR links -->
 
+[#1154]: https://github.com/munich-quantum-toolkit/qmap/pull/1154
 [#1152]: https://github.com/munich-quantum-toolkit/qmap/pull/1152
 [#1126]: https://github.com/munich-quantum-toolkit/qmap/pull/1126
 [#1116]: https://github.com/munich-quantum-toolkit/qmap/pull/1116

--- a/src/sc/Mapper.cpp
+++ b/src/sc/Mapper.cpp
@@ -55,6 +55,7 @@ void Mapper::initResults() {
   results.output.name = qc.getName() + "_mapped";
   results.output.qubits = architecture->getNqubits();
   results.output.gates = std::numeric_limits<std::size_t>::max();
+  qcMapped.setName(qc.getName());
   qcMapped.addQubitRegister(architecture->getNqubits());
 }
 

--- a/test/python/sc/test_compile.py
+++ b/test/python/sc/test_compile.py
@@ -50,6 +50,15 @@ def test_either_arch_or_calibration(example_circuit: QuantumCircuit) -> None:
         compile_(example_circuit, arch=None, calibration=None)
 
 
+def test_circuit_name_is_preserved(example_circuit: QuantumCircuit) -> None:
+    """Test that mapping preserves the input circuit name."""
+    example_circuit.name = "my_bell_chain"
+
+    mapped, _ = compile_(example_circuit, arch=Arch.IBM_QX4, method=Method.exact)
+
+    assert mapped.name == example_circuit.name
+
+
 # test that all available architecture enumerations can be properly used
 @pytest.mark.parametrize(
     "arch",


### PR DESCRIPTION
🤖 *AI text below* 🤖

## Description

This is the base of a two-PR stack; #1153 should be merged after this PR.

Copy the input circuit name to the mapped circuit in the shared mapper initialization path. This preserves `QuantumCircuit.name` across both heuristic and exact mapping and avoids downstream rejection of unnamed circuits.

Add an exact-mapper regression test that checks the returned Qiskit circuit retains the input name.

AI assistance disclosure: GPT-5 via Codex traced the shared mapper initialization, implemented the one-line fix and focused test, and ran the reported validation.

Fixes #1151

## Checklist

- [x] The pull request only contains commits that are focused and relevant to this change.
- [x] I have added appropriate tests that cover the new/changed functionality.
- [x] I have updated the documentation to reflect these changes.
- [x] I have added entries to the changelog for any noteworthy additions, changes, fixes, or removals.
- [x] I have added migration instructions to the upgrade guide (if needed).
- [x] The changes follow the project's style guidelines and introduce no new warnings.
- [x] The changes are fully tested and pass the CI checks.
- [x] I have reviewed my own code changes.

**If PR contains AI-assisted content:**

- [x] Any agent that created, edited, or submitted GitHub content was explicitly authorized for that scope, as required by our [AI Usage Guidelines](https://github.com/munich-quantum-toolkit/qmap/blob/main/docs/ai_usage.md).
- [x] Every agent-authored or agent-edited public text body begins with the visible disclosure `🤖 *AI text below* 🤖` (titles are exempt).
- [x] I have disclosed AI assistance in the PR description.
- [x] I confirm that I have personally reviewed and understood all AI-generated content, and accept full responsibility for it.