### PR TITLE
⬆️ Update workflows to v2.4.1

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -9,7 +9,7 @@ permissions: {}
 jobs:
   build-sdist:
     name: 🐍 Packaging
-    uses: munich-quantum-toolkit/workflows/.github/workflows/reusable-python-packaging-sdist.yml@3cbd664d352731ddf77bbe65569adb9621bb2fa0 # v2.4.0
+    uses: munich-quantum-toolkit/workflows/.github/workflows/reusable-python-packaging-sdist.yml@99af11652a4238dbe50ebe4b003a9f0fd5fb8085 # v2.4.1
     permissions:
       contents: read
 
@@ -28,7 +28,7 @@ jobs:
             windows-2025,
             windows-11-arm,
           ]
-    uses: munich-quantum-toolkit/workflows/.github/workflows/reusable-python-packaging-wheel-cibuildwheel.yml@3cbd664d352731ddf77bbe65569adb9621bb2fa0 # v2.4.0
+    uses: munich-quantum-toolkit/workflows/.github/workflows/reusable-python-packaging-wheel-cibuildwheel.yml@99af11652a4238dbe50ebe4b003a9f0fd5fb8085 # v2.4.1
     with:
       runs-on: ${{ matrix.runs-on }}
       setup-z3: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ permissions: {}
 jobs:
   change-detection:
     name: 🔍 Change
-    uses: munich-quantum-toolkit/workflows/.github/workflows/reusable-change-detection.yml@3cbd664d352731ddf77bbe65569adb9621bb2fa0 # v2.4.0
+    uses: munich-quantum-toolkit/workflows/.github/workflows/reusable-change-detection.yml@99af11652a4238dbe50ebe4b003a9f0fd5fb8085 # v2.4.1
     permissions:
       contents: read
 
@@ -37,7 +37,7 @@ jobs:
             compiler: gcc
             preset: debug
             run-on-draft: true
-    uses: munich-quantum-toolkit/workflows/.github/workflows/reusable-cpp-tests-ubuntu.yml@3cbd664d352731ddf77bbe65569adb9621bb2fa0 # v2.4.0
+    uses: munich-quantum-toolkit/workflows/.github/workflows/reusable-cpp-tests-ubuntu.yml@99af11652a4238dbe50ebe4b003a9f0fd5fb8085 # v2.4.1
     with:
       runs-on: ${{ matrix.runs-on }}
       compiler: ${{ matrix.compiler }}
@@ -63,7 +63,7 @@ jobs:
             compiler: clang
             preset: debug
             run-on-draft: true
-    uses: munich-quantum-toolkit/workflows/.github/workflows/reusable-cpp-tests-macos.yml@3cbd664d352731ddf77bbe65569adb9621bb2fa0 # v2.4.0
+    uses: munich-quantum-toolkit/workflows/.github/workflows/reusable-cpp-tests-macos.yml@99af11652a4238dbe50ebe4b003a9f0fd5fb8085 # v2.4.1
     with:
       runs-on: ${{ matrix.runs-on }}
       compiler: ${{ matrix.compiler }}
@@ -89,7 +89,7 @@ jobs:
             compiler: msvc
             preset: debug
             run-on-draft: true
-    uses: munich-quantum-toolkit/workflows/.github/workflows/reusable-cpp-tests-windows.yml@3cbd664d352731ddf77bbe65569adb9621bb2fa0 # v2.4.0
+    uses: munich-quantum-toolkit/workflows/.github/workflows/reusable-cpp-tests-windows.yml@99af11652a4238dbe50ebe4b003a9f0fd5fb8085 # v2.4.1
     with:
       runs-on: ${{ matrix.runs-on }}
       compiler: ${{ matrix.compiler }}
@@ -103,7 +103,7 @@ jobs:
     name: 🇨 Coverage
     needs: change-detection
     if: fromJSON(needs.change-detection.outputs.run-cpp-tests)
-    uses: munich-quantum-toolkit/workflows/.github/workflows/reusable-cpp-coverage.yml@3cbd664d352731ddf77bbe65569adb9621bb2fa0 # v2.4.0
+    uses: munich-quantum-toolkit/workflows/.github/workflows/reusable-cpp-coverage.yml@99af11652a4238dbe50ebe4b003a9f0fd5fb8085 # v2.4.1
     with:
       setup-z3: true
     permissions:
@@ -114,7 +114,7 @@ jobs:
     name: 🇨 Lint
     needs: change-detection
     if: fromJSON(needs.change-detection.outputs.run-cpp-linter)
-    uses: munich-quantum-toolkit/workflows/.github/workflows/reusable-cpp-linter.yml@3cbd664d352731ddf77bbe65569adb9621bb2fa0 # v2.4.0
+    uses: munich-quantum-toolkit/workflows/.github/workflows/reusable-cpp-linter.yml@99af11652a4238dbe50ebe4b003a9f0fd5fb8085 # v2.4.1
     with:
       clang-version: 20
       files-changed-only: true
@@ -134,7 +134,7 @@ jobs:
       fail-fast: false
       matrix:
         runs-on: [ubuntu-24.04, ubuntu-24.04-arm, macos-26, windows-2025]
-    uses: munich-quantum-toolkit/workflows/.github/workflows/reusable-python-tests.yml@3cbd664d352731ddf77bbe65569adb9621bb2fa0 # v2.4.0
+    uses: munich-quantum-toolkit/workflows/.github/workflows/reusable-python-tests.yml@99af11652a4238dbe50ebe4b003a9f0fd5fb8085 # v2.4.1
     with:
       runs-on: ${{ matrix.runs-on }}
       setup-z3: true
@@ -145,7 +145,7 @@ jobs:
     name: 🐍 Coverage
     needs: [change-detection, python-tests]
     if: fromJSON(needs.change-detection.outputs.run-python-tests)
-    uses: munich-quantum-toolkit/workflows/.github/workflows/reusable-python-coverage.yml@3cbd664d352731ddf77bbe65569adb9621bb2fa0 # v2.4.0
+    uses: munich-quantum-toolkit/workflows/.github/workflows/reusable-python-coverage.yml@99af11652a4238dbe50ebe4b003a9f0fd5fb8085 # v2.4.1
     permissions:
       contents: read
       id-token: write
@@ -154,7 +154,7 @@ jobs:
     name: 🐍 Lint
     needs: change-detection
     if: fromJSON(needs.change-detection.outputs.run-python-linter)
-    uses: munich-quantum-toolkit/workflows/.github/workflows/reusable-python-linter.yml@3cbd664d352731ddf77bbe65569adb9621bb2fa0 # v2.4.0
+    uses: munich-quantum-toolkit/workflows/.github/workflows/reusable-python-linter.yml@99af11652a4238dbe50ebe4b003a9f0fd5fb8085 # v2.4.1
     with:
       check-stubs: true
       enable-mypy: false
@@ -167,7 +167,7 @@ jobs:
     name: 🚀 CD
     needs: change-detection
     if: fromJSON(needs.change-detection.outputs.run-cd)
-    uses: munich-quantum-toolkit/workflows/.github/workflows/reusable-python-packaging-sdist.yml@3cbd664d352731ddf77bbe65569adb9621bb2fa0 # v2.4.0
+    uses: munich-quantum-toolkit/workflows/.github/workflows/reusable-python-packaging-sdist.yml@99af11652a4238dbe50ebe4b003a9f0fd5fb8085 # v2.4.1
     permissions:
       contents: read
 
@@ -186,7 +186,7 @@ jobs:
             windows-2025,
             windows-11-arm,
           ]
-    uses: munich-quantum-toolkit/workflows/.github/workflows/reusable-python-packaging-wheel-cibuildwheel.yml@3cbd664d352731ddf77bbe65569adb9621bb2fa0 # v2.4.0
+    uses: munich-quantum-toolkit/workflows/.github/workflows/reusable-python-packaging-wheel-cibuildwheel.yml@99af11652a4238dbe50ebe4b003a9f0fd5fb8085 # v2.4.1
     with:
       runs-on: ${{ matrix.runs-on }}
       setup-z3: true

--- a/.github/workflows/update-mqt-core.yml
+++ b/.github/workflows/update-mqt-core.yml
@@ -23,7 +23,7 @@ permissions: {}
 jobs:
   update-mqt-core:
     name: ⬆️ Update MQT Core
-    uses: munich-quantum-toolkit/workflows/.github/workflows/reusable-mqt-core-update.yml@3cbd664d352731ddf77bbe65569adb9621bb2fa0 # v2.4.0
+    uses: munich-quantum-toolkit/workflows/.github/workflows/reusable-mqt-core-update.yml@99af11652a4238dbe50ebe4b003a9f0fd5fb8085 # v2.4.1
     with:
       update-to-head: ${{ github.event.inputs.update-to-head == 'true' }}
     secrets:

--- a/.github/workflows/update-mqt-core.yml
+++ b/.github/workflows/update-mqt-core.yml
@@ -4,12 +4,6 @@ on:
     # run once a month on the first day of the month at 00:00 UTC
     - cron: "0 0 1 * *"
   workflow_dispatch:
-    inputs:
-      update-to-head:
-        description: "Update to the latest commit on the default branch"
-        type: boolean
-        required: false
-        default: false
   pull_request:
     paths:
       - .github/workflows/update-mqt-core.yml
@@ -25,7 +19,7 @@ jobs:
     name: ⬆️ Update MQT Core
     uses: munich-quantum-toolkit/workflows/.github/workflows/reusable-mqt-core-update.yml@99af11652a4238dbe50ebe4b003a9f0fd5fb8085 # v2.4.1
     with:
-      update-to-head: ${{ github.event.inputs.update-to-head == 'true' }}
+      max-major-version: "3"
     secrets:
       APP_ID: ${{ secrets.APP_ID }}
       APP_PRIVATE_KEY: ${{ secrets.APP_PRIVATE_KEY }}

--- a/.github/workflows/upstream.yml
+++ b/.github/workflows/upstream.yml
@@ -21,7 +21,7 @@ jobs:
       fail-fast: false
       matrix:
         runs-on: [ubuntu-24.04, macos-26, windows-2025]
-    uses: munich-quantum-toolkit/workflows/.github/workflows/reusable-qiskit-upstream-tests.yml@3cbd664d352731ddf77bbe65569adb9621bb2fa0 # v2.4.0
+    uses: munich-quantum-toolkit/workflows/.github/workflows/reusable-qiskit-upstream-tests.yml@99af11652a4238dbe50ebe4b003a9f0fd5fb8085 # v2.4.1
     with:
       runs-on: ${{ matrix.runs-on }}
       setup-z3: true
@@ -32,7 +32,7 @@ jobs:
     name: Create issue on failure
     needs: qiskit-upstream-tests
     if: ${{ always() }}
-    uses: munich-quantum-toolkit/workflows/.github/workflows/reusable-qiskit-upstream-issue.yml@3cbd664d352731ddf77bbe65569adb9621bb2fa0 # v2.4.0
+    uses: munich-quantum-toolkit/workflows/.github/workflows/reusable-qiskit-upstream-issue.yml@99af11652a4238dbe50ebe4b003a9f0fd5fb8085 # v2.4.1
     with:
       tests-result: ${{ needs.qiskit-upstream-tests.result }}
     permissions:


### PR DESCRIPTION
## Description

🤖 *AI text below* 🤖

Update `munich-quantum-toolkit/workflows` to `v2.4.1`, with full commit SHA pins.

Cap MQT Core updates at major version 3 and remove the incompatible `update-to-head` option.

## AI notice

This PR and its contents were created with the assistance of GPT-6 Astra via Codex.

## Checklist

- [x] The pull request only contains commits that are focused and relevant to this change.
- [x] ~~I have added appropriate tests that cover the new/changed functionality.~~
- [x] ~~I have updated the documentation to reflect these changes.~~
- [x] ~~I have added entries to the changelog for any noteworthy additions, changes, fixes, or removals.~~
- [x] ~~I have added migration instructions to the upgrade guide (if needed).~~
- [x] The changes follow the project's style guidelines and introduce no new warnings.
- [x] The changes are fully tested and pass the CI checks.
- [x] I have reviewed my own code changes.

**If PR contains AI-assisted content:**

- [x] Any agent that created, edited, or submitted GitHub content was explicitly authorized for that scope, as required by our [AI Usage Guidelines](https://github.com/munich-quantum-toolkit/qmap/blob/main/docs/ai_usage.md).
- [x] Every agent-authored or agent-edited public text body begins with the visible disclosure `🤖 *AI text below* 🤖` (titles are exempt).
- [x] I have disclosed AI assistance in the PR description.
- [x] I confirm that I have personally reviewed and understood all AI-generated content, and accept full responsibility for it.
